### PR TITLE
Refactor lists of results from web service queries.

### DIFF
--- a/lib/alma.rb
+++ b/lib/alma.rb
@@ -3,6 +3,12 @@ require 'alma/config'
 require 'alma/api'
 require 'alma/alma_record'
 require 'alma/user'
+require 'alma/result_set'
+require 'alma/loan_set'
+require 'alma/user_set'
+require 'alma/fine_set'
+require 'alma/user_set'
+require 'alma/request_set'
 
 module Alma
 

--- a/lib/alma/alma_record.rb
+++ b/lib/alma/alma_record.rb
@@ -1,11 +1,9 @@
 module Alma
   class AlmaRecord
 
-    attr_accessor :id
-
-    def initialize(response_hash)
-      @response = response_hash
-      @id = response_hash['primary_id']
+    def initialize(record)
+      @raw_record = record
+      post_initialize()
     end
 
     def method_missing(name)
@@ -18,7 +16,12 @@ module Alma
     end
 
     def response
-      @response
+      @raw_record
+    end
+
+    def post_initialize
+      # Subclasses can define this method to perform extra initialization
+      # after the super class init.
     end
 
   end

--- a/lib/alma/fine_set.rb
+++ b/lib/alma/fine_set.rb
@@ -1,0 +1,21 @@
+module Alma
+  class FineSet < ResultSet
+
+    def top_level_key
+      'fees'
+    end
+
+    def response_records_key
+      'fee'
+    end
+
+    def sum
+      @ws_response['fees'].fetch('total_sum', 0)
+    end
+
+    def currency
+      @ws_response['fees'].fetch('total_sum', nil)
+    end
+
+  end
+end

--- a/lib/alma/loan_set.rb
+++ b/lib/alma/loan_set.rb
@@ -1,0 +1,23 @@
+module Alma
+  class LoanSet
+
+    attr_reader :total_record_count, :list
+
+    def initialize(ws_response)
+      @ws_response = ws_response
+      @total_record_count = ws_response.fetch(total_record_count, 0)
+      @list ||= list_results
+    end
+
+    def response_records
+      @ws_response['item_loans'].fetch('item_loan',[])
+    end
+
+    def list_results
+      response_records.map do |loan|
+        Alma::AlmaRecord.new(loan)
+      end
+    end
+
+  end
+end

--- a/lib/alma/request_set.rb
+++ b/lib/alma/request_set.rb
@@ -1,0 +1,14 @@
+module Alma
+  class RequestSet < ResultSet
+
+
+    def top_level_key
+      'user_requests'
+    end
+
+    def response_records_key
+      'user_request'
+    end
+
+  end
+end

--- a/lib/alma/result_set.rb
+++ b/lib/alma/result_set.rb
@@ -1,0 +1,41 @@
+module Alma
+  class ResultSet
+
+    def initialize(ws_response)
+      @ws_response = ws_response
+    end
+
+
+    def total_record_count
+      @ws_response[top_level_key].fetch('total_record_count', 0).to_i
+    end
+
+    def list
+      @list ||= list_results
+    end
+
+    private
+    def top_level_key
+      raise NotImplementedError 'Subclasses of ResultSet Need to define the top level key'
+    end
+
+    def response_records_key
+      raise NotImplementedError 'Subclasses of ResultSet Need to define the key for response records'
+    end
+
+
+    def response_records
+      @ws_response[top_level_key].fetch(response_records_key,[])
+    end
+
+    def list_results
+      #If there is only one record in the response, HTTParty returns as a hash, not
+      # an array of hashes, so wrap in array to normalize.
+      response_array = (total_record_count == 1) ? [response_records] : response_records
+
+      response_array.map do |record|
+        Alma::AlmaRecord.new(record)
+      end
+    end
+  end
+end

--- a/lib/alma/user_set.rb
+++ b/lib/alma/user_set.rb
@@ -1,0 +1,29 @@
+module Alma
+  class UserSet
+
+    attr_reader :total_record_count, :list
+
+    def initialize(ws_response)
+      @ws_response = ws_response
+    end
+
+    def total_record_count
+      @ws_response['users'].fetch('total_record_count', 0)
+    end
+
+    def list
+      @list ||= list_results
+    end
+
+    private
+    def response_records
+      @ws_response['users'].fetch('user',[])
+    end
+
+    def list_results
+      response_records.map do |fee|
+        Alma::AlmaRecord.new(fee)
+      end
+    end
+  end
+end

--- a/spec/fixtures/requests.xml
+++ b/spec/fixtures/requests.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<user_requests total_record_count="1">
+  <user_request>
+    <request_id>83013520000121</request_id>
+    <request_type>HOLD</request_type>
+    <title>Test title</title>
+    <pickup_location>Burns</pickup_location>
+    <pickup_location_type>LIBRARY</pickup_location_type>
+    <pickup_location_library>BURNS</pickup_location_library>
+    <material_type>BK</material_type>
+    <request_status>Not Started</request_status>
+    <request_date>2013-11-12Z</request_date>
+  </user_request>
+</user_requests>

--- a/spec/lib/user_spec.rb
+++ b/spec/lib/user_spec.rb
@@ -11,8 +11,10 @@ RSpec.configure do |config|
         to_return(:status => 200,
                   :body => File.open(SPEC_ROOT + '/fixtures/fines.xml').read,
                   :headers => { 'content-type' => ['application/xml;charset=UTF-8']})
-
-
+    stub_request(:get, /.*\.exlibrisgroup\.com\/almaws\/v1\/users\/.*\/requests\/.*/).
+        to_return(:status => 200,
+                  :body => File.open(SPEC_ROOT + '/fixtures/requests.xml').read,
+                  :headers => { 'content-type' => ['application/xml;charset=UTF-8']})
   end
 end
 
@@ -75,9 +77,51 @@ describe Alma::User do
 
 
       it 'responds to total_records' do
-        expect(fines).to respond_to :total_results
-
+        expect(fines).to respond_to :total_record_count
       end
+
+      it 'lists the expected number of results' do
+        expect(fines.total_record_count).to eql 4
+      end
+
+      it 'has the expected number of results' do
+        expect(fines.list.size).to eql 4
+      end
+
+      it 'responds to sum' do
+        expect(fines).to respond_to :sum
+      end
+
+      it 'lists the expected summed total' do
+        expect(fines.sum).to eql "415.0"
+      end
+
+    end
+
+    describe "#{described_class}.requests" do
+      let(:requests) {described_class.get_requests({:user_id => "johns"})}
+
+
+      it 'responds to total_records' do
+        expect(requests).to respond_to :total_record_count
+      end
+
+      it 'lists the expected number of results' do
+        expect(requests.total_record_count).to eql 1
+      end
+
+      it 'responds to list' do
+        expect(requests).to respond_to :list
+      end
+
+      it 'returns an array when list is called' do
+        expect(requests.list).to be_an Array
+      end
+
+      it 'has the expected number of results' do
+        expect(requests.list.size).to eql 1
+      end
+
     end
   end
 end


### PR DESCRIPTION
@skng5 Have a look. One breaking change. 
`users.total_count` now becomes `users.total_record_count`.

Stop using Structs, and define actual classes for represeting the response of a
web service query.

Alter the interface of results to follow naming convention in raw results.