### PR TITLE
Add multi renew

### DIFF
--- a/lib/alma/renewal_response.rb
+++ b/lib/alma/renewal_response.rb
@@ -32,7 +32,7 @@ module Alma
 
     def message
       if @success
-        "#{item_title} is now due #{new_due_date}"
+        "#{item_title} is now due #{due_date}"
       else
         "#{item_title} could not be renewed."
       end

--- a/lib/alma/user.rb
+++ b/lib/alma/user.rb
@@ -1,5 +1,3 @@
-
-
 module Alma
   class  User < AlmaRecord
     extend Alma::Api
@@ -31,8 +29,8 @@ module Alma
       response
     end
 
-    def renew_multiple_loans(array_of_loan_ids)
-      array_of_loan_ids.map { |id| renew_loan(id) }
+    def renew_multiple_loans(loan_ids)
+      loan_ids.map { |id| renew_loan(id) }
     end
 
     def renew_all_loans
@@ -114,6 +112,25 @@ module Alma
         response = resources.almaws_v1_users.user_id_loans_loan_id.post(params)
         RenewalResponse.new(response)
       end
+
+      # Attempts to renew a multiple items for a user
+      # @param [Hash] args
+      # @option args [String] :user_id The unique id of the user
+      # @option args [Array<String>] :loan_ids Array of loan ids
+      # @option args [String] :user_id_type Type of identifier being used to search. OPTIONAL
+      # @return [Array<RenewalResponse>] Object indicating the renewal message
+      def renew_multiple_loans(args)
+
+        if args.fetch(:loans_ids, nil).respond_to? :map
+          args.delete(:loan_ids).map do |loan_id|
+            renew_loan(args.merge(loan_id: loan_id))
+          end
+        else
+          []
+        end
+      end
+
+
 
 
       def set_wadl_filename

--- a/lib/alma/user.rb
+++ b/lib/alma/user.rb
@@ -25,8 +25,18 @@ module Alma
 
     def renew_loan(loan_id)
       response = self.class.renew_loan({user_id: self.id, loan_id: loan_id})
-      @recheck_loans = true if response.renewed?
+      if response.renewed?
+        @recheck_loans ||= true
+      end
       response
+    end
+
+    def renew_multiple_loans(array_of_loan_ids)
+      array_of_loan_ids.map { |id| renew_loan(id) }
+    end
+
+    def renew_all_loans
+      renew_multiple_loans(loans.map(&:loan_id))
     end
 
     def recheck_loans?

--- a/spec/fixtures/renewal_success.xml
+++ b/spec/fixtures/renewal_success.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <item_loan>
-  <loan_id>1234</loan_id>
+  <loan_id>RENEWED_ID</loan_id>
   <circ_desk desc="default circ desk">DEFAULT_CIRC_DESK</circ_desk>
   <library desc="Main Library">MAIN</library>
   <user_id>ID1234</user_id>

--- a/spec/lib/renewal_response_spec.rb
+++ b/spec/lib/renewal_response_spec.rb
@@ -1,0 +1,40 @@
+require "spec_helper"
+
+describe Alma::RenewalResponse do
+  before(:all) do
+    Alma.configure
+  end
+
+  let(:renewal) { Alma::User.renew_loan({loan_id: 'RENEWED_ID', user_id: 'ID1234'})}
+
+  context 'successful renewal' do
+    describe '#renewed?' do
+      it 'returns true' do
+        expect(renewal.renewed?).to be true
+      end
+    end
+
+    describe '#due_date' do
+      it 'returns a timestamp of the new due date' do
+        expect(renewal.due_date).to eql '2014-06-23T14:00:00.000Z'
+      end
+    end
+
+    describe '#item_title' do
+      it 'rturns the title of the renewed object' do
+        expect(renewal.item_title).to eql 'History'
+      end
+    end
+
+
+    describe '#error_message' do
+      it 'is empty' do
+        expect(renewal.error_message).to be_empty
+      end
+    end
+
+  end
+
+
+
+end

--- a/spec/lib/user_spec.rb
+++ b/spec/lib/user_spec.rb
@@ -106,36 +106,6 @@ describe Alma::User do
 
     end
 
-    describe "#{described_class}.renew_loan" do
-      let(:renew){described_class.renew_loan({user_id: 'johns', loan_id: "RENEWED_ID"})}
-
-      context 'Successful renewal' do
-
-        it '#renewed? should be true' do
-          expect(renew.renewed?).to be true
-        end
-
-        it 'provides a renwal date string' do
-          expect(renew.due_date).to eql '2014-06-23T14:00:00.000Z'
-        end
-
-        it 'provides the title' do
-          expect(renew.item_title).to eql 'History'
-        end
-
-        it 'returns an empty error message' do
-          expect(renew.error_message).to be_empty
-        end
-
-
-      end
-
-      context 'Failed Renewal' do
-
-      end
-
-    end
-
     describe "#{described_class}.authenticate" do
       let(:auth_success) {described_class.authenticate({user_id: 'johns', password: 'right_password'}) }
       let(:auth_fail) {described_class.authenticate({user_id: 'johns', password: 'wrong_password'}) }


### PR DESCRIPTION
Adds ability to renew multiple items with a single call, including a `renew all` convenience method.

  