### PR TITLE
BL-747 Item limits

### DIFF
--- a/lib/alma/bib_item.rb
+++ b/lib/alma/bib_item.rb
@@ -16,7 +16,7 @@ module Alma
       options.select! {|k,_| PERMITTED_ARGS.include? k }
       url = "#{bibs_base_path}/#{mms_id}/holdings/#{holding_id}/items"
       response = HTTParty.get(url, headers: headers, query: options)
-      BibItemSet.new(response)
+      BibItemSet.new(response, options.merge({mms_id: mms_id, holding_id: holding_id}))
     end
 
     def initialize(item)
@@ -50,7 +50,6 @@ module Alma
     def location_name
       in_temp_location? ? temp_location_name : holding_location_name
     end
-
 
     def holding_library
       item_data.dig("library", "value")

--- a/spec/fixtures/bib_items-pg1.json
+++ b/spec/fixtures/bib_items-pg1.json
@@ -1,0 +1,12705 @@
+{
+  "item": [
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903540003811",
+        "barcode": "39074024498321",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2008-12-05Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.152 (Jul.7-Sep.29, 2008)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903540003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903530003811",
+        "barcode": "39074024508319",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2009-06-09Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.152-152/153 (Oct.6, 2008-Jan.5, 2009)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903530003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903520003811",
+        "barcode": "39074024523342",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2009-11-05Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.153 (Apr.6-Jun.29, 2009)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903520003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903510003811",
+        "barcode": "39074024523748",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2009-11-06Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.153 (Jan.12-Mar.30, 2009)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903510003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903500003811",
+        "barcode": "39074024531",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2010-03-03Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.154 (Jul.6-Sep.28, 2009)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903500003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903490003811",
+        "barcode": "39074024532061",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2010-03-04Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.154-155 (Oct.5, 2009-Jan.4, 2010)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903490003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903480003811",
+        "barcode": "39074025209925",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2015-04-10Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.104 (Oct.-Dec. 1984)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903480003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903470003811",
+        "barcode": "39074025209917",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2015-04-10Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.106 (Jul.-Sept. 1985)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903470003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903460003811",
+        "barcode": "39074024547440",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2010-08-13Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.155 (Jan.-Mar.2010)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903460003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903450003811",
+        "barcode": "39074024551913",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2010-10-08Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.155 (Apr.-Jul.5, 2010)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903450003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903440003811",
+        "barcode": "39074027149913",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2011-01-13Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.156 (Jul.12-Sep.2010)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903440003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903430003811",
+        "barcode": "39074020768016",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.3 (Jan.-Jun. 1934)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903430003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903420003811",
+        "barcode": "39074020768008",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.4 (Jul.-Dec. 1934)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903420003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903410003811",
+        "barcode": "39074020767968",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.5 (Jan.-Jun. 1935)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903410003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903400003811",
+        "barcode": "39074020767976",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.6 (Jul.-Dec. 1935)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903400003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903390003811",
+        "barcode": "39074020767984",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.7 (Jan.-Mar. 1936)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903390003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903380003811",
+        "barcode": "39074020769170",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.7 (Apr.-Jun. 1936)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903380003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903370003811",
+        "barcode": "39074020769204",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.8 (Jul.-Dec. 1936)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903370003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903360003811",
+        "barcode": "39074020769196",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.9 (Jan.-Jun. 1937)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903360003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903350003811",
+        "barcode": "39074020769188",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.10 (Jul.-Dec. 1937)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903350003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903340003811",
+        "barcode": "39074020769162",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.11 (Jan.-Jun. 1938)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903340003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903330003811",
+        "barcode": "39074020769121",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.12 (Jul.-Dec. 1938)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903330003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903320003811",
+        "barcode": "39074020769139",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.13 (Jan.-Mar. 1939)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903320003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903310003811",
+        "barcode": "39074020769154",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.13 (Apr.-Jun. 1939)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903310003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903300003811",
+        "barcode": "39074020769014",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.15 (Jan.-Jun. 1940)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903300003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903290003811",
+        "barcode": "39074020769147",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.16 (Jul.-Dec. 1940)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903290003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903280003811",
+        "barcode": "39074020769212",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.17 (Jan.-Mar. 1941)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903280003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903270003811",
+        "barcode": "39074020769220",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.17 (Apr.-Jun. 1941)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903270003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903260003811",
+        "barcode": "39074020769022",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.18 (Oct.-Dec. 1941)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903260003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903250003811",
+        "barcode": "39074020769030",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.18 (Jul.-Sep. 1941)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903250003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903240003811",
+        "barcode": "39074020769048",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.19 (Jan.-Mar. 1942)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903240003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903230003811",
+        "barcode": "39074020769055",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.19 (Apr.-Jun. 1942)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903230003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903220003811",
+        "barcode": "39074020769071",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.20 (Oct.-Dec. 1942)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903220003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903210003811",
+        "barcode": "39074020769063",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.20 (Jul.-Sep. 1942)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903210003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903200003811",
+        "barcode": "39074020769089",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.21 (Jan.-Mar. 1943)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903200003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903190003811",
+        "barcode": "39074020769097",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.21 (Apr.-Jun. 1943)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903190003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903180003811",
+        "barcode": "39074020769105",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.22 (Jul.-Sep. 1943)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903180003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903170003811",
+        "barcode": "39074020769113",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.22 (Oct.-Dec. 1943)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903170003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903160003811",
+        "barcode": "39074020768933",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.23 (Jan.-Mar. 1944)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903160003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903150003811",
+        "barcode": "39074020768941",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.23 (Apr.-Jun. 1944)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903150003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903140003811",
+        "barcode": "39074020768958",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.24 (Jul.-Sep. 1944)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903140003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903130003811",
+        "barcode": "39074020768966",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.24 (Oct.-Dec. 1944)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903130003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903120003811",
+        "barcode": "39074020768974",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.25 (Jan.-Mar. 1945)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903120003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903110003811",
+        "barcode": "39074027162775",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "0",
+          "desc": "Item not in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.25 (Apr.-Jun. 1945)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "TECHNICAL",
+          "desc": "Technical - Migration"
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "MESSAGE(ITEM): Fri Dec 02 2011 09:44AM: IN TRANSIT from davist to kstk",
+        "internal_note_1": "Status: t - IN TRANSIT | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903110003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903100003811",
+        "barcode": "39074020768990",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.26 (Jul.-Sep. 1945)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903100003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903090003811",
+        "barcode": "39074020769006",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.26 (Oct.-Dec. 1945)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903090003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903080003811",
+        "barcode": "39074020768685",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.27 (Jan.-Mar.1946)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903080003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903070003811",
+        "barcode": "39074020768693",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.27 (Apr.-Jun. 1946)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903070003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903060003811",
+        "barcode": "39074020768909",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.28 (Jul.-Sep. 1946)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903060003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903050003811",
+        "barcode": "39074020768917",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.28 (Oct.-Dec. 1946)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903050003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903040003811",
+        "barcode": "39074020768925",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.29 (Jan.-Mar. 1947)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903040003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903030003811",
+        "barcode": "39074020768867",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.42 (Jul.-Sep. 1953)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903030003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903020003811",
+        "barcode": "39074020768875",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.29 (Apr.-Jun. 1947)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903020003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903010003811",
+        "barcode": "39074020768883",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.30 (Jul.-Sep. 1947)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903010003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903000003811",
+        "barcode": "39074020768891",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.30 (Oct. Dec. 1947)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903000003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311902990003811",
+        "barcode": "39074020768842",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.31 (Jan.-Mar. 1948)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311902990003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311902980003811",
+        "barcode": "39074020768859",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.31 (Apr.-Jun. 1948)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311902980003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311902970003811",
+        "barcode": "39074020768834",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.32 (Jul.-Sep. 1948)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311902970003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311902960003811",
+        "barcode": "39074020768826",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.32 (Oct.-Dec. 1948)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311902960003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311902950003811",
+        "barcode": "39074020768792",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.33 (Jan.-Mar. 1949)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311902950003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311902940003811",
+        "barcode": "39074020768800",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.33 (Apr.-Jun. 1949)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311902940003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311902930003811",
+        "barcode": "39074020768818",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.34 (Oct.-Dec. 1949)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311902930003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311902920003811",
+        "barcode": "39074020768750",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.34 (Jul.-Sep. 1949)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311902920003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311902910003811",
+        "barcode": "39074020768768",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.35 (Jan.-Mar. 1950)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311902910003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311902900003811",
+        "barcode": "39074020768776",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.35 (Apr.-Jun. 1950)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311902900003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311902890003811",
+        "barcode": "39074020768784",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.36 (Jul.-Sep. 1950)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311902890003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311902880003811",
+        "barcode": "39074020768727",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.36 (Oct.-Dec. 1950)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311902880003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311902870003811",
+        "barcode": "39074020768735",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.37 (Jan.-Mar. 1951)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311902870003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311902860003811",
+        "barcode": "39074020768743",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.37 (Apr.-Jun. 1951)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311902860003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311902840003811",
+        "barcode": "39074020768719",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.38 (Oct.-Dec. 1951)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311902840003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311902830003811",
+        "barcode": "39074020768636",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.39 (Jan.-Mar. 1952)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311902830003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311902820003811",
+        "barcode": "39074020768644",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.39 (Apr.-Jun. 1952)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311902820003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311902800003811",
+        "barcode": "39074020768669",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.41 (Jan.-Mar. 1953)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311902800003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311902790003811",
+        "barcode": "39074020768677",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.41 (Apr.-Jun. 1953)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311902790003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311902780003811",
+        "barcode": "39074020768628",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.42 (Oct.-Dec. 1953)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311902780003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311902770003811",
+        "barcode": "39074020768610",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.43 (Apr.-Jun. 1954)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311902770003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311902760003811",
+        "barcode": "39074020768578",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.43 (Jan.-Mar. 1954)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311902760003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311902750003811",
+        "barcode": "39074020768586",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.44 (Jul.-Sep. 1954)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311902750003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311902740003811",
+        "barcode": "39074020768602",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.44 (Oct.-Dec. 1954)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311902740003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311902730003811",
+        "barcode": "39074020768594",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.45 (Jan.-Mar. 1955)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311902730003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311902720003811",
+        "barcode": "39074020767661",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.45 (Apr.-Jun. 1955)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311902720003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311902700003811",
+        "barcode": "39074020767687",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.47 (Jan.-Mar. 1956)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311902700003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311902690003811",
+        "barcode": "39074020767547",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.47 (Apr.-Jun. 1956)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311902690003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311902680003811",
+        "barcode": "39074020767554",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.48 (Jul.-Sep. 1956)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311902680003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311902670003811",
+        "barcode": "39074020767562",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.48 (Oct.-Dec. 1956)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311902670003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311902660003811",
+        "barcode": "39074020726451",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.49 (Jan.-Mar. 1957)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311902660003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311902650003811",
+        "barcode": "39074020767570",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.49 (Apr.Jun. 1957)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311902650003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311902640003811",
+        "barcode": "39074020767471",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.50 (Oct.-Dec. 1957)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311902640003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311902630003811",
+        "barcode": "39074020767489",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.50 (Jul.-Sep. 1957)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311902630003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311902620003811",
+        "barcode": "39074020767497",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.51 (Jan.-Mar. 1958)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311902620003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311902610003811",
+        "barcode": "39074020767505",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.51 (Apr.-Jun. 1958)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311902610003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311902600003811",
+        "barcode": "39074020767513",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.52 (Jul.-Sep. 1958)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311902600003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311902590003811",
+        "barcode": "39074020767521",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.52 (Oct.-Dec. 1958)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311902590003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311902580003811",
+        "barcode": "39074020767539",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.53 (Apr.-Jun. 1959)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311902580003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311902570003811",
+        "barcode": "39074020767364",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.53 (Jan.-Mar. 1959)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311902570003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311902560003811",
+        "barcode": "39074020767372",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.54 (Jul.-Sep. 1959)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311902560003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311902550003811",
+        "barcode": "39074020767380",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.54 (Oct.-Dec. 1959)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311902550003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311902540003811",
+        "barcode": "39074020767398",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2018-11-28Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.55 (Jan.-Mar. 1960)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311902540003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311902530003811",
+        "barcode": "39074020767406",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2018-11-27Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.55 (Apr.-Jun. 1960)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311902530003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311902520003811",
+        "barcode": "39074020767414",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2018-11-27Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.56 (Jul.-Sep. 1960)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311902520003811"
+    }
+  ],
+  "total_record_count": 290
+}

--- a/spec/fixtures/bib_items-pg2.json
+++ b/spec/fixtures/bib_items-pg2.json
@@ -1,0 +1,12705 @@
+{
+  "item": [
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903530003811",
+        "barcode": "39074024508319",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2009-06-09Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.152-152/153 (Oct.6, 2008-Jan.5, 2009)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903530003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903520003811",
+        "barcode": "39074024523342",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2009-11-05Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.153 (Apr.6-Jun.29, 2009)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903520003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903510003811",
+        "barcode": "39074024523748",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2009-11-06Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.153 (Jan.12-Mar.30, 2009)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903510003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903500003811",
+        "barcode": "39074024531",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2010-03-03Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.154 (Jul.6-Sep.28, 2009)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903500003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903490003811",
+        "barcode": "39074024532061",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2010-03-04Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.154-155 (Oct.5, 2009-Jan.4, 2010)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903490003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903480003811",
+        "barcode": "39074025209925",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2015-04-10Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.104 (Oct.-Dec. 1984)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903480003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903470003811",
+        "barcode": "39074025209917",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2015-04-10Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.106 (Jul.-Sept. 1985)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903470003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903460003811",
+        "barcode": "39074024547440",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2010-08-13Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.155 (Jan.-Mar.2010)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903460003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903450003811",
+        "barcode": "39074024551913",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2010-10-08Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.155 (Apr.-Jul.5, 2010)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903450003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903440003811",
+        "barcode": "39074027149913",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2011-01-13Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.156 (Jul.12-Sep.2010)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903440003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903430003811",
+        "barcode": "39074020768016",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.3 (Jan.-Jun. 1934)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903430003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903420003811",
+        "barcode": "39074020768008",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.4 (Jul.-Dec. 1934)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903420003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903410003811",
+        "barcode": "39074020767968",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.5 (Jan.-Jun. 1935)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903410003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903400003811",
+        "barcode": "39074020767976",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.6 (Jul.-Dec. 1935)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903400003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903390003811",
+        "barcode": "39074020767984",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.7 (Jan.-Mar. 1936)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903390003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903380003811",
+        "barcode": "39074020769170",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.7 (Apr.-Jun. 1936)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903380003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903370003811",
+        "barcode": "39074020769204",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.8 (Jul.-Dec. 1936)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903370003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903360003811",
+        "barcode": "39074020769196",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.9 (Jan.-Jun. 1937)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903360003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903350003811",
+        "barcode": "39074020769188",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.10 (Jul.-Dec. 1937)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903350003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903340003811",
+        "barcode": "39074020769162",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.11 (Jan.-Jun. 1938)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903340003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903330003811",
+        "barcode": "39074020769121",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.12 (Jul.-Dec. 1938)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903330003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903320003811",
+        "barcode": "39074020769139",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.13 (Jan.-Mar. 1939)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903320003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903310003811",
+        "barcode": "39074020769154",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.13 (Apr.-Jun. 1939)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903310003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903300003811",
+        "barcode": "39074020769014",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.15 (Jan.-Jun. 1940)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903300003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903290003811",
+        "barcode": "39074020769147",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.16 (Jul.-Dec. 1940)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903290003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903280003811",
+        "barcode": "39074020769212",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.17 (Jan.-Mar. 1941)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903280003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903270003811",
+        "barcode": "39074020769220",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.17 (Apr.-Jun. 1941)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903270003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903260003811",
+        "barcode": "39074020769022",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.18 (Oct.-Dec. 1941)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903260003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903250003811",
+        "barcode": "39074020769030",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.18 (Jul.-Sep. 1941)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903250003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903240003811",
+        "barcode": "39074020769048",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.19 (Jan.-Mar. 1942)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903240003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903230003811",
+        "barcode": "39074020769055",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.19 (Apr.-Jun. 1942)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903230003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903220003811",
+        "barcode": "39074020769071",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.20 (Oct.-Dec. 1942)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903220003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903210003811",
+        "barcode": "39074020769063",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.20 (Jul.-Sep. 1942)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903210003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903200003811",
+        "barcode": "39074020769089",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.21 (Jan.-Mar. 1943)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903200003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903190003811",
+        "barcode": "39074020769097",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.21 (Apr.-Jun. 1943)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903190003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903180003811",
+        "barcode": "39074020769105",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.22 (Jul.-Sep. 1943)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903180003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903170003811",
+        "barcode": "39074020769113",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.22 (Oct.-Dec. 1943)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903170003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903160003811",
+        "barcode": "39074020768933",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.23 (Jan.-Mar. 1944)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903160003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903150003811",
+        "barcode": "39074020768941",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.23 (Apr.-Jun. 1944)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903150003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903140003811",
+        "barcode": "39074020768958",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.24 (Jul.-Sep. 1944)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903140003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903130003811",
+        "barcode": "39074020768966",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.24 (Oct.-Dec. 1944)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903130003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903120003811",
+        "barcode": "39074020768974",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.25 (Jan.-Mar. 1945)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903120003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903110003811",
+        "barcode": "39074027162775",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "0",
+          "desc": "Item not in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.25 (Apr.-Jun. 1945)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "TECHNICAL",
+          "desc": "Technical - Migration"
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "MESSAGE(ITEM): Fri Dec 02 2011 09:44AM: IN TRANSIT from davist to kstk",
+        "internal_note_1": "Status: t - IN TRANSIT | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903110003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903100003811",
+        "barcode": "39074020768990",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.26 (Jul.-Sep. 1945)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903100003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903090003811",
+        "barcode": "39074020769006",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.26 (Oct.-Dec. 1945)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903090003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903080003811",
+        "barcode": "39074020768685",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.27 (Jan.-Mar.1946)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903080003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903070003811",
+        "barcode": "39074020768693",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.27 (Apr.-Jun. 1946)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903070003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903060003811",
+        "barcode": "39074020768909",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.28 (Jul.-Sep. 1946)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903060003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903050003811",
+        "barcode": "39074020768917",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.28 (Oct.-Dec. 1946)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903050003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903040003811",
+        "barcode": "39074020768925",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.29 (Jan.-Mar. 1947)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903040003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903030003811",
+        "barcode": "39074020768867",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.42 (Jul.-Sep. 1953)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903030003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903020003811",
+        "barcode": "39074020768875",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.29 (Apr.-Jun. 1947)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903020003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903010003811",
+        "barcode": "39074020768883",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.30 (Jul.-Sep. 1947)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903010003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903000003811",
+        "barcode": "39074020768891",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.30 (Oct. Dec. 1947)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903000003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311902990003811",
+        "barcode": "39074020768842",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.31 (Jan.-Mar. 1948)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311902990003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311902980003811",
+        "barcode": "39074020768859",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.31 (Apr.-Jun. 1948)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311902980003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311902970003811",
+        "barcode": "39074020768834",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.32 (Jul.-Sep. 1948)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311902970003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311902960003811",
+        "barcode": "39074020768826",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.32 (Oct.-Dec. 1948)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311902960003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311902950003811",
+        "barcode": "39074020768792",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.33 (Jan.-Mar. 1949)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311902950003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311902940003811",
+        "barcode": "39074020768800",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.33 (Apr.-Jun. 1949)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311902940003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311902930003811",
+        "barcode": "39074020768818",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.34 (Oct.-Dec. 1949)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311902930003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311902920003811",
+        "barcode": "39074020768750",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.34 (Jul.-Sep. 1949)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311902920003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311902910003811",
+        "barcode": "39074020768768",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.35 (Jan.-Mar. 1950)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311902910003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311902900003811",
+        "barcode": "39074020768776",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.35 (Apr.-Jun. 1950)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311902900003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311902890003811",
+        "barcode": "39074020768784",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.36 (Jul.-Sep. 1950)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311902890003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311902880003811",
+        "barcode": "39074020768727",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.36 (Oct.-Dec. 1950)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311902880003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311902870003811",
+        "barcode": "39074020768735",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.37 (Jan.-Mar. 1951)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311902870003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311902860003811",
+        "barcode": "39074020768743",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.37 (Apr.-Jun. 1951)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311902860003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311902840003811",
+        "barcode": "39074020768719",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.38 (Oct.-Dec. 1951)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311902840003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311902830003811",
+        "barcode": "39074020768636",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.39 (Jan.-Mar. 1952)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311902830003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311902820003811",
+        "barcode": "39074020768644",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.39 (Apr.-Jun. 1952)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311902820003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311902800003811",
+        "barcode": "39074020768669",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.41 (Jan.-Mar. 1953)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311902800003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311902790003811",
+        "barcode": "39074020768677",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.41 (Apr.-Jun. 1953)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311902790003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311902780003811",
+        "barcode": "39074020768628",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.42 (Oct.-Dec. 1953)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311902780003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311902770003811",
+        "barcode": "39074020768610",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.43 (Apr.-Jun. 1954)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311902770003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311902760003811",
+        "barcode": "39074020768578",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.43 (Jan.-Mar. 1954)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311902760003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311902750003811",
+        "barcode": "39074020768586",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.44 (Jul.-Sep. 1954)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311902750003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311902740003811",
+        "barcode": "39074020768602",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.44 (Oct.-Dec. 1954)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311902740003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311902730003811",
+        "barcode": "39074020768594",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.45 (Jan.-Mar. 1955)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311902730003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311902720003811",
+        "barcode": "39074020767661",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.45 (Apr.-Jun. 1955)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311902720003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311902700003811",
+        "barcode": "39074020767687",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.47 (Jan.-Mar. 1956)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311902700003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311902690003811",
+        "barcode": "39074020767547",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.47 (Apr.-Jun. 1956)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311902690003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311902680003811",
+        "barcode": "39074020767554",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.48 (Jul.-Sep. 1956)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311902680003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311902670003811",
+        "barcode": "39074020767562",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.48 (Oct.-Dec. 1956)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311902670003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311902660003811",
+        "barcode": "39074020726451",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.49 (Jan.-Mar. 1957)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311902660003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311902650003811",
+        "barcode": "39074020767570",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.49 (Apr.Jun. 1957)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311902650003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311902640003811",
+        "barcode": "39074020767471",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.50 (Oct.-Dec. 1957)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311902640003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311902630003811",
+        "barcode": "39074020767489",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.50 (Jul.-Sep. 1957)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311902630003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311902620003811",
+        "barcode": "39074020767497",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.51 (Jan.-Mar. 1958)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311902620003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311902610003811",
+        "barcode": "39074020767505",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.51 (Apr.-Jun. 1958)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311902610003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311902600003811",
+        "barcode": "39074020767513",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.52 (Jul.-Sep. 1958)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311902600003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311902590003811",
+        "barcode": "39074020767521",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.52 (Oct.-Dec. 1958)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311902590003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311902580003811",
+        "barcode": "39074020767539",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.53 (Apr.-Jun. 1959)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311902580003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311902570003811",
+        "barcode": "39074020767364",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.53 (Jan.-Mar. 1959)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311902570003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311902560003811",
+        "barcode": "39074020767372",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.54 (Jul.-Sep. 1959)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311902560003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311902550003811",
+        "barcode": "39074020767380",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.54 (Oct.-Dec. 1959)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311902550003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311902540003811",
+        "barcode": "39074020767398",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2018-11-28Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.55 (Jan.-Mar. 1960)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311902540003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311902530003811",
+        "barcode": "39074020767406",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2018-11-27Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.55 (Apr.-Jun. 1960)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311902530003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311902520003811",
+        "barcode": "39074020767414",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2018-11-27Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.56 (Jul.-Sep. 1960)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311902520003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311902510003811",
+        "barcode": "39074020767422",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2018-11-27Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.56 (Oct.-Dec. 1960)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311902510003811"
+    }
+  ],
+  "total_record_count": 290
+}

--- a/spec/fixtures/bib_items-pg3.json
+++ b/spec/fixtures/bib_items-pg3.json
@@ -1,0 +1,11435 @@
+{
+  "item": [
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903520003811",
+        "barcode": "39074024523342",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2009-11-05Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.153 (Apr.6-Jun.29, 2009)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903520003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903510003811",
+        "barcode": "39074024523748",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2009-11-06Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.153 (Jan.12-Mar.30, 2009)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903510003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903500003811",
+        "barcode": "39074024531",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2010-03-03Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.154 (Jul.6-Sep.28, 2009)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903500003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903490003811",
+        "barcode": "39074024532061",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2010-03-04Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.154-155 (Oct.5, 2009-Jan.4, 2010)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903490003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903480003811",
+        "barcode": "39074025209925",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2015-04-10Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.104 (Oct.-Dec. 1984)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903480003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903470003811",
+        "barcode": "39074025209917",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2015-04-10Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.106 (Jul.-Sept. 1985)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903470003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903460003811",
+        "barcode": "39074024547440",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2010-08-13Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.155 (Jan.-Mar.2010)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903460003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903450003811",
+        "barcode": "39074024551913",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2010-10-08Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.155 (Apr.-Jul.5, 2010)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903450003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903440003811",
+        "barcode": "39074027149913",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2011-01-13Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.156 (Jul.12-Sep.2010)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903440003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903430003811",
+        "barcode": "39074020768016",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.3 (Jan.-Jun. 1934)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903430003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903420003811",
+        "barcode": "39074020768008",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.4 (Jul.-Dec. 1934)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903420003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903410003811",
+        "barcode": "39074020767968",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.5 (Jan.-Jun. 1935)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903410003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903400003811",
+        "barcode": "39074020767976",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.6 (Jul.-Dec. 1935)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903400003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903390003811",
+        "barcode": "39074020767984",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.7 (Jan.-Mar. 1936)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903390003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903380003811",
+        "barcode": "39074020769170",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.7 (Apr.-Jun. 1936)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903380003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903370003811",
+        "barcode": "39074020769204",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.8 (Jul.-Dec. 1936)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903370003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903360003811",
+        "barcode": "39074020769196",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.9 (Jan.-Jun. 1937)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903360003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903350003811",
+        "barcode": "39074020769188",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.10 (Jul.-Dec. 1937)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903350003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903340003811",
+        "barcode": "39074020769162",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.11 (Jan.-Jun. 1938)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903340003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903330003811",
+        "barcode": "39074020769121",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.12 (Jul.-Dec. 1938)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903330003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903320003811",
+        "barcode": "39074020769139",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.13 (Jan.-Mar. 1939)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903320003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903310003811",
+        "barcode": "39074020769154",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.13 (Apr.-Jun. 1939)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903310003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903300003811",
+        "barcode": "39074020769014",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.15 (Jan.-Jun. 1940)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903300003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903290003811",
+        "barcode": "39074020769147",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.16 (Jul.-Dec. 1940)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903290003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903280003811",
+        "barcode": "39074020769212",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.17 (Jan.-Mar. 1941)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903280003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903270003811",
+        "barcode": "39074020769220",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.17 (Apr.-Jun. 1941)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903270003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903260003811",
+        "barcode": "39074020769022",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.18 (Oct.-Dec. 1941)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903260003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903250003811",
+        "barcode": "39074020769030",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.18 (Jul.-Sep. 1941)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903250003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903240003811",
+        "barcode": "39074020769048",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.19 (Jan.-Mar. 1942)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903240003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903230003811",
+        "barcode": "39074020769055",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.19 (Apr.-Jun. 1942)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903230003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903220003811",
+        "barcode": "39074020769071",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.20 (Oct.-Dec. 1942)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903220003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903210003811",
+        "barcode": "39074020769063",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.20 (Jul.-Sep. 1942)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903210003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903200003811",
+        "barcode": "39074020769089",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.21 (Jan.-Mar. 1943)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903200003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903190003811",
+        "barcode": "39074020769097",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.21 (Apr.-Jun. 1943)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903190003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903180003811",
+        "barcode": "39074020769105",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.22 (Jul.-Sep. 1943)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903180003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903170003811",
+        "barcode": "39074020769113",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.22 (Oct.-Dec. 1943)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903170003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903160003811",
+        "barcode": "39074020768933",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.23 (Jan.-Mar. 1944)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903160003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903150003811",
+        "barcode": "39074020768941",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.23 (Apr.-Jun. 1944)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903150003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903140003811",
+        "barcode": "39074020768958",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.24 (Jul.-Sep. 1944)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903140003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903130003811",
+        "barcode": "39074020768966",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.24 (Oct.-Dec. 1944)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903130003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903120003811",
+        "barcode": "39074020768974",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.25 (Jan.-Mar. 1945)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903120003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903110003811",
+        "barcode": "39074027162775",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "0",
+          "desc": "Item not in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.25 (Apr.-Jun. 1945)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "TECHNICAL",
+          "desc": "Technical - Migration"
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "MESSAGE(ITEM): Fri Dec 02 2011 09:44AM: IN TRANSIT from davist to kstk",
+        "internal_note_1": "Status: t - IN TRANSIT | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903110003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903100003811",
+        "barcode": "39074020768990",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.26 (Jul.-Sep. 1945)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903100003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903090003811",
+        "barcode": "39074020769006",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.26 (Oct.-Dec. 1945)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903090003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903080003811",
+        "barcode": "39074020768685",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.27 (Jan.-Mar.1946)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903080003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903070003811",
+        "barcode": "39074020768693",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.27 (Apr.-Jun. 1946)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903070003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903060003811",
+        "barcode": "39074020768909",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.28 (Jul.-Sep. 1946)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903060003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903050003811",
+        "barcode": "39074020768917",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.28 (Oct.-Dec. 1946)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903050003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903040003811",
+        "barcode": "39074020768925",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.29 (Jan.-Mar. 1947)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903040003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903030003811",
+        "barcode": "39074020768867",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.42 (Jul.-Sep. 1953)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903030003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903020003811",
+        "barcode": "39074020768875",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.29 (Apr.-Jun. 1947)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903020003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903010003811",
+        "barcode": "39074020768883",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.30 (Jul.-Sep. 1947)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903010003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311903000003811",
+        "barcode": "39074020768891",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.30 (Oct. Dec. 1947)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311903000003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311902990003811",
+        "barcode": "39074020768842",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.31 (Jan.-Mar. 1948)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311902990003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311902980003811",
+        "barcode": "39074020768859",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.31 (Apr.-Jun. 1948)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311902980003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311902970003811",
+        "barcode": "39074020768834",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.32 (Jul.-Sep. 1948)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311902970003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311902960003811",
+        "barcode": "39074020768826",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.32 (Oct.-Dec. 1948)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311902960003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311902950003811",
+        "barcode": "39074020768792",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.33 (Jan.-Mar. 1949)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311902950003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311902940003811",
+        "barcode": "39074020768800",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.33 (Apr.-Jun. 1949)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311902940003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311902930003811",
+        "barcode": "39074020768818",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.34 (Oct.-Dec. 1949)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311902930003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311902920003811",
+        "barcode": "39074020768750",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.34 (Jul.-Sep. 1949)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311902920003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311902910003811",
+        "barcode": "39074020768768",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.35 (Jan.-Mar. 1950)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311902910003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311902900003811",
+        "barcode": "39074020768776",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.35 (Apr.-Jun. 1950)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311902900003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311902890003811",
+        "barcode": "39074020768784",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.36 (Jul.-Sep. 1950)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311902890003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311902880003811",
+        "barcode": "39074020768727",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.36 (Oct.-Dec. 1950)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311902880003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311902870003811",
+        "barcode": "39074020768735",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.37 (Jan.-Mar. 1951)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311902870003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311902860003811",
+        "barcode": "39074020768743",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.37 (Apr.-Jun. 1951)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311902860003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311902840003811",
+        "barcode": "39074020768719",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.38 (Oct.-Dec. 1951)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311902840003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311902830003811",
+        "barcode": "39074020768636",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.39 (Jan.-Mar. 1952)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311902830003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311902820003811",
+        "barcode": "39074020768644",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.39 (Apr.-Jun. 1952)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311902820003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311902800003811",
+        "barcode": "39074020768669",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.41 (Jan.-Mar. 1953)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311902800003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311902790003811",
+        "barcode": "39074020768677",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.41 (Apr.-Jun. 1953)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311902790003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311902780003811",
+        "barcode": "39074020768628",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.42 (Oct.-Dec. 1953)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311902780003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311902770003811",
+        "barcode": "39074020768610",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.43 (Apr.-Jun. 1954)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311902770003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311902760003811",
+        "barcode": "39074020768578",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.43 (Jan.-Mar. 1954)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311902760003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311902750003811",
+        "barcode": "39074020768586",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.44 (Jul.-Sep. 1954)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311902750003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311902740003811",
+        "barcode": "39074020768602",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.44 (Oct.-Dec. 1954)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311902740003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311902730003811",
+        "barcode": "39074020768594",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.45 (Jan.-Mar. 1955)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311902730003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311902720003811",
+        "barcode": "39074020767661",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.45 (Apr.-Jun. 1955)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311902720003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311902700003811",
+        "barcode": "39074020767687",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.47 (Jan.-Mar. 1956)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311902700003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311902690003811",
+        "barcode": "39074020767547",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.47 (Apr.-Jun. 1956)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311902690003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311902680003811",
+        "barcode": "39074020767554",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.48 (Jul.-Sep. 1956)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311902680003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311902670003811",
+        "barcode": "39074020767562",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.48 (Oct.-Dec. 1956)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311902670003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311902660003811",
+        "barcode": "39074020726451",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.49 (Jan.-Mar. 1957)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311902660003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311902650003811",
+        "barcode": "39074020767570",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.49 (Apr.Jun. 1957)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311902650003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311902640003811",
+        "barcode": "39074020767471",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.50 (Oct.-Dec. 1957)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311902640003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311902630003811",
+        "barcode": "39074020767489",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.50 (Jul.-Sep. 1957)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311902630003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311902620003811",
+        "barcode": "39074020767497",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.51 (Jan.-Mar. 1958)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311902620003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311902610003811",
+        "barcode": "39074020767505",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.51 (Apr.-Jun. 1958)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311902610003811"
+    },
+    {
+      "bib_data": {
+        "mms_id": "991026207509703811",
+        "title": "Newsweek.",
+        "author": null,
+        "issn": "0028-9604",
+        "isbn": null,
+        "complete_edition": "",
+        "network_number": [
+          "(OCLC)ocm01760328",
+          "ocm01760328",
+          "PATG92-S06527",
+          "ocn471940703",
+          "(PPT)b15412805-01tuli_inst"
+        ],
+        "place_of_publication": "[Los Angeles, Calif., etc.,",
+        "publisher_const": "Newsweek Inc etc",
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811"
+      },
+      "holding_data": {
+        "holding_id": "22311903550003811",
+        "call_number_type": {
+          "value": "0",
+          "desc": "Library of Congress classification"
+        },
+        "call_number": "AP2 .N6772",
+        "accession_number": "",
+        "copy_id": "1",
+        "in_temp_location": false,
+        "temp_library": {
+          "value": null,
+          "desc": null
+        },
+        "temp_location": {
+          "value": null,
+          "desc": null
+        },
+        "temp_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "temp_call_number": "",
+        "temp_policy": {
+          "value": "",
+          "desc": null
+        },
+        "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811"
+      },
+      "item_data": {
+        "pid": "23311902600003811",
+        "barcode": "39074020767513",
+        "creation_date": "2017-06-20Z",
+        "modification_date": "2017-06-20Z",
+        "base_status": {
+          "value": "1",
+          "desc": "Item in place"
+        },
+        "physical_material_type": {
+          "value": "ISSUE",
+          "desc": "Issue"
+        },
+        "policy": {
+          "value": "2",
+          "desc": "Bound Journal"
+        },
+        "provenance": {
+          "value": "",
+          "desc": null
+        },
+        "po_line": "",
+        "is_magnetic": false,
+        "arrival_date": "2006-06-30Z",
+        "year_of_issue": "",
+        "enumeration_a": "",
+        "enumeration_b": "",
+        "enumeration_c": "",
+        "enumeration_d": "",
+        "enumeration_e": "",
+        "enumeration_f": "",
+        "enumeration_g": "",
+        "enumeration_h": "",
+        "chronology_i": "",
+        "chronology_j": "",
+        "chronology_k": "",
+        "chronology_l": "",
+        "chronology_m": "",
+        "description": "v.52 (Jul.-Sep. 1958)",
+        "receiving_operator": "import",
+        "process_type": {
+          "value": "",
+          "desc": null
+        },
+        "library": {
+          "value": "KARDON",
+          "desc": "Remote Storage"
+        },
+        "location": {
+          "value": "p_remote",
+          "desc": "Paley Remote Stacks"
+        },
+        "alternative_call_number": "",
+        "alternative_call_number_type": {
+          "value": "",
+          "desc": null
+        },
+        "storage_location_id": "",
+        "pages": "",
+        "pieces": "$0.00",
+        "public_note": "",
+        "fulfillment_note": "",
+        "internal_note_1": "Status: o - LIB USE ONLY | INT NOTE: Temporarily transferred from PSTK to KSTK as of 10.14.2011",
+        "internal_note_2": "",
+        "internal_note_3": "ITEM LOC: kstk",
+        "statistics_note_1": "TOT RENEW: 0",
+        "statistics_note_2": "LYCIRC: 0",
+        "statistics_note_3": "",
+        "requested": false,
+        "edition": null,
+        "imprint": null,
+        "language": null,
+        "physical_condition": {
+          "value": null,
+          "desc": null
+        }
+      },
+      "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026207509703811/holdings/22311903550003811/items/23311902600003811"
+    }
+  ],
+  "total_record_count": 290
+}

--- a/spec/fixtures/bib_items-pg4.json
+++ b/spec/fixtures/bib_items-pg4.json
@@ -1,0 +1,4 @@
+{
+  "item": [],
+  "total_record_count": 290
+}

--- a/spec/lib/bib_item_set_spec.rb
+++ b/spec/lib/bib_item_set_spec.rb
@@ -19,6 +19,7 @@ describe Alma::BibItemSet do
     describe '#filter_missing_and_lost' do
       it 'filters the missing and lost items' do
       expect(bib_item_set.filter_missing_and_lost.size).to eq 2
+      end
     end
 
     describe '#grouped_by_library' do
@@ -32,5 +33,28 @@ describe Alma::BibItemSet do
         expect(grouped["AMBLER"].size).to eq 1
       end
     end
+
+    describe 'all' do
+      let(:bib_item_set) { Alma::BibItem.find("991026207509703811") }
+
+      it 'responds to all' do
+        expect(bib_item_set).to respond_to :all
+      end
+
+      it 'should make three calls to the api' do
+        # Our fixture object has 290 records
+        bib_item_set.all.map(&:item_data)
+        expect(WebMock).to have_requested(:get, /.*\.exlibrisgroup\.com\/almaws\/v1\/bibs\/991026207509703811\/holdings\/.*\/items/).times(4)
+      end
+
+      it "loops over multiple pages of results" do
+        expect(bib_item_set.all.map(&:item_data).size).to eql 290
+      end
+    end
+
+    describe "success?" do
+      it "returns true when response code is 200" do
+        expect(bib_item_set.success?).to be true
+      end
+    end
   end
-end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -32,7 +32,7 @@ RSpec.configure do |config|
                   :body => File.open(SPEC_ROOT + '/fixtures/requests-pg2.json'))
 
     stub_request(:get, /.*\/users\/.*\/requests.*/).
-        with(query: hash_including({offset: "200" })).  
+        with(query: hash_including({offset: "200" })).
         to_return(:status => 200,
                   :body => File.open(SPEC_ROOT + '/fixtures/requests-pg3.json'))
 
@@ -67,19 +67,36 @@ RSpec.configure do |config|
         to_return(:status => 200,
                   :body => File.open(SPEC_ROOT + '/fixtures/renewal_success.json'))
 
-
-
-
-
     # Request bibs info
 
     stub_request(:get, /.*\.exlibrisgroup\.com\/almaws\/v1\/bibs/).
         to_return(:status => 200,
                   :body => File.open(SPEC_ROOT + '/fixtures/multiple_bibs.json'))
 
-    stub_request(:get, /.*\.exlibrisgroup\.com\/almaws\/v1\/bibs\/.*\/holdings\/.*\/items/).
+    stub_request(:get, /.*\.exlibrisgroup\.com\/almaws\/v1\/bibs\/foo\/holdings\/.*\/items/).
         to_return(:status => 200,
                   :body => File.open(SPEC_ROOT + '/fixtures/bib_items.json'))
+
+    # Bib items sets
+
+    stub_request(:get, /.*\.exlibrisgroup\.com\/almaws\/v1\/bibs\/991026207509703811\/holdings\/.*\/items.*/).
+        to_return(:status => 200,
+                  :body => File.open(SPEC_ROOT + '/fixtures/bib_items-pg1.json'))
+
+    stub_request(:get, /.*\.exlibrisgroup\.com\/almaws\/v1\/bibs\/991026207509703811\/holdings\/.*\/items.*/).
+        with(query: hash_including({offset: "100" })).
+        to_return(:status => 200,
+                  :body => File.open(SPEC_ROOT + '/fixtures/bib_items-pg2.json'))
+
+    stub_request(:get, /.*\.exlibrisgroup\.com\/almaws\/v1\/bibs\/991026207509703811\/holdings\/.*\/items.*/).
+        with(query: hash_including({offset: "200" })).
+        to_return(:status => 200,
+                  :body => File.open(SPEC_ROOT + '/fixtures/bib_items-pg3.json'))
+
+    stub_request(:get, /.*\.exlibrisgroup\.com\/almaws\/v1\/bibs\/991026207509703811\/holdings\/.*\/items.*/).
+        with(query: hash_including({offset: "300" })).
+        to_return(:status => 200,
+                  :body => File.open(SPEC_ROOT + '/fixtures/bib_items-pg4.json'))
 
     # Request options
 


### PR DESCRIPTION
Currently item limits in requests are making it impossible for patrons to request items that come from large sets of records since it is limited to the first 100 records.  This change is similar to what was implemented for loans and request sets so that we can access all of the records in the request drop downs.