### PR TITLE
[BL-779] Add a loggable values interface.

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ Alma.configure do |config|
   config.apikey     = 'EXAMPLE_EL_DEV_NETWORK_APPLICATION_KEY'
   # Alma gem defaults to querying Ex Libris's North American  Api servers. You can override that here.
   config.region   = "https://api-eu.hosted.exlibrisgroup.com
+
+  # By default enable_loggagle is set to false
+  config.enable_loggagle = false
 end
 ```
 
@@ -230,7 +233,10 @@ item.public_note
 
 ```
 
+### Logging
+This gem exposes a loggable interface to responses.  Thus a response will respond to `loggable` and return a hash with state values that may be of use to log.
 
+As a bonus, when we enable this feature using the `enable_loggable` configuration, error messages will contain the loggable values and be formatted as JSON.
 
 ## Development
 

--- a/lib/alma/config.rb
+++ b/lib/alma/config.rb
@@ -9,12 +9,12 @@ module Alma
   end
 
   class Configuration
-    attr_accessor :apikey, :region
+    attr_accessor :apikey, :region, :enable_loggable
 
     def initialize
       @apikey = "TEST_API_KEY"
       @region = 'https://api-na.hosted.exlibrisgroup.com'
+      @enable_loggable = false
     end
-
   end
 end

--- a/lib/alma/error.rb
+++ b/lib/alma/error.rb
@@ -11,5 +11,16 @@ module Alma::Error
   def error
     @response.fetch('web_service_result', {})
   end
+end
 
+module Alma
+  class StandardError < ::StandardError
+    def initialize(message, loggable = {})
+      if Alma.configuration.enable_loggable
+        message = { error: message }.merge(loggable).to_json
+      end
+
+      super message
+    end
+  end
 end

--- a/lib/alma/fine_set.rb
+++ b/lib/alma/fine_set.rb
@@ -2,16 +2,31 @@
 
 module Alma
   class FineSet < ResultSet
-
+    class ResponseError < Alma::StandardError
+    end
 
     attr_reader :results, :raw_response
     def_delegators :results, :empty?
 
     def initialize(raw_response)
       @raw_response = raw_response
-      @response = JSON.parse(raw_response.body)
+      @response = raw_response.parsed_response
+      validate(raw_response)
       @results = @response.fetch(key, [])
         .map { |item| single_record_class.new(item) }
+    end
+
+    def loggable
+      { uri: @raw_response&.request&.uri.to_s
+      }.select { |k, v| !(v.nil? || v.empty?) }
+    end
+
+    def validate(response)
+      if response.code != 200
+        message = "Could not find fines."
+        log = loggable.merge(response.parsed_response)
+        raise ResponseError.new(message, log)
+      end
     end
 
     def each(&block)

--- a/lib/alma/item_request_options.rb
+++ b/lib/alma/item_request_options.rb
@@ -1,11 +1,22 @@
 module Alma
   class ItemRequestOptions < RequestOptions
 
+    class ResponseError < Alma::StandardError
+    end
+
     def self.get(mms_id, holding_id=nil, item_pid=nil, options={})
       url = "#{bibs_base_path}/#{mms_id}/holdings/#{holding_id}/items/#{item_pid}/request-options"
       options.select! {|k,_|  REQUEST_OPTIONS_PERMITTED_ARGS.include? k }
       response = HTTParty.get(url, headers: headers, query: options)
       new(response)
+    end
+
+    def validate(response)
+      if response.code != 200
+        message = "Could not get item request options."
+        log = loggable.merge(response.parsed_response)
+        raise ResponseError.new(message, log)
+      end
     end
   end
 end

--- a/lib/alma/renewal_response.rb
+++ b/lib/alma/renewal_response.rb
@@ -1,11 +1,15 @@
 module Alma
   class RenewalResponse
 
-
-
     def initialize(response)
-      @response = response
+      @raw_response = response
+      @response = response.parsed_response
       @success  = response.has_key?('loan_id')
+    end
+
+    def loggable
+      { uri: @raw_response&.request&.uri.to_s
+      }.select { |k, v| !(v.nil? || v.empty?) }
     end
 
     def renewed?

--- a/lib/alma/request.rb
+++ b/lib/alma/request.rb
@@ -1,5 +1,8 @@
 module Alma
   class BibRequest
+    class  ItemAlreadyExists < Alma::StandardError
+    end
+
     extend Alma::ApiDefaults
 
     REQUEST_TYPES = %w[HOLD DIGITIZATION BOOKING]

--- a/lib/alma/response.rb
+++ b/lib/alma/response.rb
@@ -4,6 +4,9 @@ require "forwardable"
 
 module Alma
   class Response
+    class StandardError < Alma::StandardError
+    end
+
     extend ::Forwardable
 
     attr_reader :raw_response
@@ -11,12 +14,32 @@ module Alma
 
     def initialize(response)
       @raw_response = response
+      # We could validate and throw an error here but currently a
+      validate(response)
+    end
+
+    def loggable
+      { uri: @raw_response&.request&.uri.to_s
+      }.select { |k, v| !(v.nil? || v.empty?) }
+    end
+
+    def validate(response)
+      if errors.first&.dig("errorCode") == "401136"
+        message = "The requested item already exists."
+        log = loggable.merge(response.parsed_response)
+
+        raise Alma::BibRequest::ItemAlreadyExists.new(message, log)
+      end
+
+      if response.code != 200
+        log = loggable.merge(response.parsed_response)
+        raise StandardError.new("Invalid Response.", log)
+      end
     end
 
     # Returns an array of errors
     def errors
-      return [] if success?
-      JSON.parse(body).dig("errorList", "error") || []
+      @raw_response.parsed_response&.dig("errorList", "error") || []
     end
   end
 end

--- a/lib/alma/result_set.rb
+++ b/lib/alma/result_set.rb
@@ -16,6 +16,11 @@ class Alma::ResultSet
     @response = response_body_hash
   end
 
+  def loggable
+    { uri: @response&.request&.uri&.to_s }
+      .select { |k, v| !(v.nil? || v.empty?) }
+  end
+
   def each
     @results ||= @response.fetch(key, [])
       .map { |item| single_record_class.new(item) }

--- a/spec/lib/renewal_response_spec.rb
+++ b/spec/lib/renewal_response_spec.rb
@@ -7,8 +7,7 @@ describe Alma::RenewalResponse do
 
 
   let(:renewal) do
-    response_hash =  JSON.load(open(File.join(SPEC_ROOT,'fixtures','renewal_success.json')))
-    Alma::RenewalResponse.new response_hash
+    Alma::User.send_loan_renewal_request(user_id: "foo", loan_id: "bar")
   end
 
   context 'successful renewal' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,26 +14,31 @@ RSpec.configure do |config|
     # User details
     stub_request(:get, /.*\.exlibrisgroup\.com\/almaws\/v1\/users\/.*/).
         to_return(:status => 200,
+                  :headers => { "Content-Type" => "application/json" },
                   :body => File.open(SPEC_ROOT + '/fixtures/single_user.json').read)
 
     #fees / fines
     stub_request(:get, /.*\/users\/.*\/fees.*/).
         to_return(:status => 200,
+                  :headers => { "Content-Type" => "application/json" },
                   :body => File.open(SPEC_ROOT + '/fixtures/fines.json'))
 
     # user requests
     stub_request(:get, /.*\/users\/.*\/requests.*/).
         to_return(:status => 200,
+                  :headers => { "Content-Type" => "application/json" },
                   :body => File.open(SPEC_ROOT + '/fixtures/requests.json'))
 
     stub_request(:get, /.*\/users\/.*\/requests.*/).
         with(query: hash_including({offset: "100" })).
         to_return(:status => 200,
+                  :headers => { "Content-Type" => "application/json" },
                   :body => File.open(SPEC_ROOT + '/fixtures/requests-pg2.json'))
 
     stub_request(:get, /.*\/users\/.*\/requests.*/).
         with(query: hash_including({offset: "200" })).
         to_return(:status => 200,
+                  :headers => { "Content-Type" => "application/json" },
                   :body => File.open(SPEC_ROOT + '/fixtures/requests-pg3.json'))
 
     # successful user authentication
@@ -49,63 +54,75 @@ RSpec.configure do |config|
     # user loans
     stub_request(:get, /.*\/users\/.*\/loans.*/).
         to_return(:status => 200,
+                  :headers => { "Content-Type" => "application/json" },
                   :body => File.open(SPEC_ROOT + '/fixtures/loans-pg1.json'))
 
     stub_request(:get, /.*\/users\/.*\/loans.*/).
         with(query: hash_including({offset: "100" })).
         to_return(:status => 200,
+                  :headers => { "Content-Type" => "application/json" },
                   :body => File.open(SPEC_ROOT + '/fixtures/loans-pg2.json'))
 
     stub_request(:get, /.*\/users\/.*\/loans.*/).
           with(query: hash_including({offset: "200" })).
           to_return(:status => 200,
+                  :headers => { "Content-Type" => "application/json" },
                    :body => File.open(SPEC_ROOT + '/fixtures/loans-pg3.json'))
 
     # loan renewal
     stub_request(:post, /.*\.exlibrisgroup\.com\/almaws\/v1\/users\/.*\/loans\/.*/).
         with(query: hash_including({op: 'renew'})).
         to_return(:status => 200,
+                  :headers => { "Content-Type" => "application/json" },
                   :body => File.open(SPEC_ROOT + '/fixtures/renewal_success.json'))
 
     # Request bibs info
 
     stub_request(:get, /.*\.exlibrisgroup\.com\/almaws\/v1\/bibs/).
         to_return(:status => 200,
+                  :headers => { "Content-Type" => "application/json" },
                   :body => File.open(SPEC_ROOT + '/fixtures/multiple_bibs.json'))
 
     stub_request(:get, /.*\.exlibrisgroup\.com\/almaws\/v1\/bibs\/foo\/holdings\/.*\/items/).
         to_return(:status => 200,
+                  :headers => { "Content-Type" => "application/json" },
                   :body => File.open(SPEC_ROOT + '/fixtures/bib_items.json'))
 
     # Bib items sets
 
     stub_request(:get, /.*\.exlibrisgroup\.com\/almaws\/v1\/bibs\/991026207509703811\/holdings\/.*\/items.*/).
         to_return(:status => 200,
+                  :headers => { "Content-Type" => "application/json" },
                   :body => File.open(SPEC_ROOT + '/fixtures/bib_items-pg1.json'))
 
     stub_request(:get, /.*\.exlibrisgroup\.com\/almaws\/v1\/bibs\/991026207509703811\/holdings\/.*\/items.*/).
         with(query: hash_including({offset: "100" })).
         to_return(:status => 200,
+                  :headers => { "Content-Type" => "application/json" },
                   :body => File.open(SPEC_ROOT + '/fixtures/bib_items-pg2.json'))
 
     stub_request(:get, /.*\.exlibrisgroup\.com\/almaws\/v1\/bibs\/991026207509703811\/holdings\/.*\/items.*/).
         with(query: hash_including({offset: "200" })).
         to_return(:status => 200,
+                  :headers => { "Content-Type" => "application/json" },
                   :body => File.open(SPEC_ROOT + '/fixtures/bib_items-pg3.json'))
 
     stub_request(:get, /.*\.exlibrisgroup\.com\/almaws\/v1\/bibs\/991026207509703811\/holdings\/.*\/items.*/).
         with(query: hash_including({offset: "300" })).
         to_return(:status => 200,
+                  :headers => { "Content-Type" => "application/json" },
                   :body => File.open(SPEC_ROOT + '/fixtures/bib_items-pg4.json'))
 
     # Request options
 
     stub_request(:get, /.*\.exlibrisgroup\.com\/almaws\/v1\/bibs\/.*\/request-options/).
         to_return(:status => 200,
+                  :headers => { "Content-Type" => "application/json" },
                   :body => File.open(SPEC_ROOT + '/fixtures/request_options.json'))
 
     stub_request(:get, /.*\.exlibrisgroup\.com\/almaws\/v1\/bibs\/NOHOLD\/request-options/).
         to_return(:status => 200,
+                  :headers => { "Content-Type" => "application/json" },
                   :body => File.open(SPEC_ROOT + '/fixtures/request_options_no_hold.json'))
 
     stub_request(:post, /.*\.exlibrisgroup\.com\/almaws\/v1\/bibs\/foo\/requests/).
@@ -113,16 +130,19 @@ RSpec.configure do |config|
 
     stub_request(:get,/.*\/error/).
         to_return(:status => 400,
+                  :headers => { "Content-Type" => "application/json" },
                   :body => File.open(SPEC_ROOT + '/fixtures/error.json'))
 
     # Item Level Request options
 
     stub_request(:get, /.*\.exlibrisgroup\.com\/almaws\/v1\/bibs\/.*\/holdings\/.*\/items\/.*\/request-options/).
         to_return(:status => 200,
+                  :headers => { "Content-Type" => "application/json" },
                   :body => File.open(SPEC_ROOT + '/fixtures/request_options.json'))
 
     stub_request(:get, /.*\.exlibrisgroup\.com\/almaws\/v1\/bibs\/ITEMNOHOLD\/holdings\/123\/items\/456\/request-options/).
         to_return(:status => 200,
+                  :headers => { "Content-Type" => "application/json" },
                   :body => File.open(SPEC_ROOT + '/fixtures/request_options_no_hold.json'))
 
     stub_request(:post, /.*\.exlibrisgroup\.com\/almaws\/v1\/bibs\/.*\/holdings\/.*\/items\/.*\/requests/).


### PR DESCRIPTION
REF BL-779

Adds a loggable method to the responses that contains a hash of
loggable values that can be used for logging.

Also allows for adding the loggable values as JSON in error messages.