### PR TITLE
[BL-877] Do not get items with offset over 500.

### DIFF
--- a/spec/lib/config_spec.rb
+++ b/spec/lib/config_spec.rb
@@ -36,6 +36,13 @@ describe 'Configuring Alma' do
       expect(Alma.configuration.timeout).to eql 5
     end
 
+    it "is possible to override the timeout configuration" do
+      Alma.configure do |config|
+        config.timeout = 10
+      end
+      expect(Alma.configuration.timeout).to eql 10
+    end
+
 
     after(:all) do
       Alma.configuration = nil


### PR DESCRIPTION
There is an Alma API issue where trying to retrieve items using an
offset of 500 or greater throws an error.  This is a temporary work
around that should be removed once Alma fixes the orig issue with the
API.  Expected fix is Dec 2019.