### PR TITLE
Always retrieve the max limit from collection api.

### DIFF
--- a/lib/alma/electronic.rb
+++ b/lib/alma/electronic.rb
@@ -44,7 +44,7 @@ module Alma
       limit = 100
       offset = 0
       log.info("Retrieving #{total} collection ids.")
-      groups = Array.new(total / limit, limit) + [ total % limit ]
+      groups = Array.new(total / limit + 1, limit)
       @ids ||= groups.map { |limit|
         prev_offset = offset
         offset += limit
@@ -53,7 +53,7 @@ module Alma
         .map { |params|  Thread.new { self.get(params) } }
         .map(&:value).map(&:data)
         .map { |data| data["electronic_collection"].map { |coll| coll["id"] } }
-        .flatten
+        .flatten.uniq
     end
 
     def self.http_retries


### PR DESCRIPTION
This PR updates how `Alma::Electronic.get_ids` retrieves all the ids
in our collections from the `alma/eletronic/collections` API.

Before this change if it were determined that there are a total of 101
collections, then the method would make two requests: the first to get
100 items and the second to get only 1 item.

With this change it still makes two requests, but in each case the
limit will be set to the max allowed, 100.

The reason for this change is to compensate for what looks to be a bug in
the `alma/electronic/collections` API. When retrieving all the collections the
last record of the first 100 collections is always the same as the first record
of the next 100. This does not happen for any of the other request pair (a
total of 23)