### PR TITLE
change how BibItemSet iterates over Alma api

### DIFF
--- a/lib/alma/bib_item_set.rb
+++ b/lib/alma/bib_item_set.rb
@@ -3,6 +3,7 @@
 module Alma
 
   class BibItemSet < ResultSet
+    ITEMS_PER_PAGE = 100
 
     class ResponseError < ::Alma::StandardError
     end
@@ -49,16 +50,23 @@ module Alma
     end
 
     def all
+      @last_page_index ||= false
       Enumerator.new do |yielder|
         offset = 0
-        loop do
-          r = (offset == 0) ? self : single_record_class.find(@mms_id, options=@options.merge({limit: 100, offset: offset}))
+        while (!@last_page_index || @last_page_index >= offset / items_per_page) do
+          r = (offset == 0) ? self : single_record_class.find(@mms_id, options=@options.merge({limit: items_per_page, offset: offset}))
           unless r.empty?
             r.map { |item| yielder << item }
-            offset += 100
+            @last_page_index = (offset / items_per_page)
           else
-            raise StopIteration
+            @last_page_index -= 1
           end
+
+          if r.size == items_per_page
+            @last_page_index += 1
+          end
+
+          offset += items_per_page
         end
       end
     end
@@ -77,6 +85,10 @@ module Alma
 
     def single_record_class
       Alma::BibItem
+    end
+
+    def items_per_page
+      ITEMS_PER_PAGE
     end
   end
 end

--- a/lib/alma/bib_item_set.rb
+++ b/lib/alma/bib_item_set.rb
@@ -26,7 +26,7 @@ module Alma
     end
 
     def loggable
-      { total_record_count: @total_record_count,
+      { total_record_count: @total_record_count.to_s,
         mms_id: @mms_id,
         uri: @raw_response&.request&.uri.to_s
       }.select { |k, v| !(v.nil? || v.empty?) }

--- a/spec/lib/bib_item_set_spec.rb
+++ b/spec/lib/bib_item_set_spec.rb
@@ -44,7 +44,7 @@ describe Alma::BibItemSet do
       it 'should make three calls to the api' do
         # Our fixture object has 290 records
         bib_item_set.all.map(&:item_data)
-        expect(WebMock).to have_requested(:get, /.*\.exlibrisgroup\.com\/almaws\/v1\/bibs\/991026207509703811\/holdings\/.*\/items/).times(4)
+        expect(WebMock).to have_requested(:get, /.*\.exlibrisgroup\.com\/almaws\/v1\/bibs\/991026207509703811\/holdings\/.*\/items/).times(3)
       end
 
       it "loops over multiple pages of results" do

--- a/spec/lib/bib_item_set_spec.rb
+++ b/spec/lib/bib_item_set_spec.rb
@@ -57,4 +57,16 @@ describe Alma::BibItemSet do
         expect(bib_item_set.success?).to be true
       end
     end
+
+    context "BibItemSet is initialized with a failed request" do
+      it "raises a ResponseError" do
+        response = instance_double(HTTParty::Response)
+        request = instance_double(HTTParty::Request)
+        allow(response).to receive(:request).and_return request
+        allow(request).to receive(:uri).and_return "http://example.com"
+        allow(response).to receive(:code).and_return 500
+        allow(response).to receive(:parsed_response).and_return({"total_record_count" => 1})
+        expect { Alma::BibItemSet.new(response) }.to raise_error(Alma::BibItemSet::ResponseError)
+      end
+    end
   end


### PR DESCRIPTION
I noticed that the BibItemSet::all method was calling one page more than needed. When there are lots of calls to 'all' this results in redundant requests to alma.
