### PR TITLE
change how BibItemSet iterates over Alma api (take 2)

### DIFF
--- a/lib/alma/bib_item_set.rb
+++ b/lib/alma/bib_item_set.rb
@@ -26,7 +26,7 @@ module Alma
     end
 
     def loggable
-      { total_record_count: @total_record_count,
+      { total_record_count: @total_record_count.to_s,
         mms_id: @mms_id,
         uri: @raw_response&.request&.uri.to_s
       }.select { |k, v| !(v.nil? || v.empty?) }

--- a/spec/lib/bib_item_set_spec.rb
+++ b/spec/lib/bib_item_set_spec.rb
@@ -44,11 +44,24 @@ describe Alma::BibItemSet do
       it 'should make three calls to the api' do
         # Our fixture object has 290 records
         bib_item_set.all.map(&:item_data)
-        expect(WebMock).to have_requested(:get, /.*\.exlibrisgroup\.com\/almaws\/v1\/bibs\/991026207509703811\/holdings\/.*\/items/).times(4)
+        expect(WebMock).to have_requested(:get, /.*\.exlibrisgroup\.com\/almaws\/v1\/bibs\/991026207509703811\/holdings\/.*\/items/).times(3)
       end
 
       it "loops over multiple pages of results" do
         expect(bib_item_set.all.map(&:item_data).size).to eql 290
+      end
+
+      it "doesn't error if the results are empty" do
+        response = instance_double(HTTParty::Response)
+        request = instance_double(HTTParty::Request)
+        allow(response).to receive(:request).and_return request
+        allow(request).to receive(:uri).and_return "http://example.com"
+        allow(response).to receive(:code).and_return 200
+        allow(response).to receive(:parsed_response).and_return({"total_record_count" => 1})
+        empty_bib_set = Alma::BibItemSet.new(response)
+        allow(empty_bib_set).to receive(:empty?).and_return(true)
+        allow(empty_bib_set).to receive(:all).and_call_original
+        expect { empty_bib_set.all.to_a }.not_to raise_error
       end
     end
 

--- a/spec/lib/bib_item_set_spec.rb
+++ b/spec/lib/bib_item_set_spec.rb
@@ -70,4 +70,16 @@ describe Alma::BibItemSet do
         expect(bib_item_set.success?).to be true
       end
     end
+
+    context "BibItemSet is initialized with a failed request" do
+      it "raises a ResponseError" do
+        response = instance_double(HTTParty::Response)
+        request = instance_double(HTTParty::Request)
+        allow(response).to receive(:request).and_return request
+        allow(request).to receive(:uri).and_return "http://example.com"
+        allow(response).to receive(:code).and_return 500
+        allow(response).to receive(:parsed_response).and_return({"total_record_count" => 1})
+        expect { Alma::BibItemSet.new(response) }.to raise_error(Alma::BibItemSet::ResponseError)
+      end
+    end
   end


### PR DESCRIPTION
I noticed that the BibItemSet::all method was calling one page more than needed. When there are lots of calls to 'all' this results in redundant requests to alma.

Also a small fix to prevent errors in the logging function if for some reason a response has a record count and a non 200 code.