### PR TITLE
Fix BibItem.find_by_barcode

### DIFF
--- a/lib/alma/bib_item.rb
+++ b/lib/alma/bib_item.rb
@@ -20,10 +20,8 @@ module Alma
       BibItemSet.new(response, options.merge({mms_id: mms_id, holding_id: holding_id}))
     end
 
-    def self.find_by_barcode(barcode, options={})
-      response = HTTParty.get(items_base_path, headers: headers, query: { item_barcode: barcode }, timeout: timeout, follow_redirects: false)
-      location = response.headers["location"]
-      response = HTTParty.get(location, headers: headers, query: options, timeout: timeout)
+    def self.find_by_barcode(barcode)
+      response = HTTParty.get(items_base_path, headers: headers, query: { item_barcode: barcode }, timeout: timeout, follow_redirects: true)
       new(response)
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -151,7 +151,7 @@ RSpec.configure do |config|
     # Item from barcode
     stub_request(:get, /.*\.exlibrisgroup\.com\/almaws\/v1\/items.*/).
       to_return(:status => 302,
-                headers: { "Location" => "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/99117110763506421/holdings/22195173890006421/items/23195173880006421" }
+                headers: { "Location" => "/almaws/v1/bibs/99117110763506421/holdings/22195173890006421/items/23195173880006421" }
                )
     stub_request(:get, /.*\.exlibrisgroup\.com\/almaws\/v1\/bibs\/99117110763506421\/holdings\/22195173890006421\/items\/23195173880006421.*/).
       to_return(:status => 200,


### PR DESCRIPTION
Alma actually returns a relative URL in the location header. HTTParty
can handle this, and there's no use case right now to pass further
options.