### PR TITLE
Add Alma::BibItem.scan

### DIFF
--- a/lib/alma/bib_item.rb
+++ b/lib/alma/bib_item.rb
@@ -25,6 +25,12 @@ module Alma
       new(response)
     end
 
+    def self.scan(mms_id:, holding_id:, item_pid:, options: {})
+      url = "#{bibs_base_path}/#{mms_id}/holdings/#{holding_id}/items/#{item_pid}"
+      response = HTTParty.post(url, headers: headers, query: options)
+      new(response)
+    end
+
     def initialize(item)
       @item = item
     end

--- a/spec/fixtures/scan.json
+++ b/spec/fixtures/scan.json
@@ -1,0 +1,131 @@
+{
+  "bib_data": {
+    "mms_id": "9968643943506421",
+    "title": "100 an\u0303os de seguridad social en Espan\u0303a (1900-2000) /",
+    "author": "Bretin Herrero, Constantino.",
+    "issn": null,
+    "isbn": "8498494389",
+    "complete_edition": "",
+    "network_number": [
+      "(NjP)6864394-princetondb",
+      "(OCoLC)326577503",
+      "6864394",
+      "(OCoLC)ocn326577503"
+    ],
+    "place_of_publication": "Madrid :",
+    "date_of_publication": "[2009]",
+    "publisher_const": "Dykinson",
+    "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/9968643943506421"
+  },
+  "holding_data": {
+    "holding_id": "22258767470006421",
+    "call_number_type": {
+      "value": "0",
+      "desc": "Library of Congress classification"
+    },
+    "call_number": "KKT1504 .B748 2009",
+    "accession_number": "",
+    "copy_id": "1",
+    "in_temp_location": false,
+    "temp_library": {
+      "value": null,
+      "desc": null
+    },
+    "temp_location": {
+      "value": null,
+      "desc": null
+    },
+    "temp_call_number_type": {
+      "value": "",
+      "desc": null
+    },
+    "temp_call_number": "",
+    "temp_policy": {
+      "value": "",
+      "desc": null
+    },
+    "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/9968643943506421/holdings/22258767470006421"
+  },
+  "item_data": {
+    "pid": "23258767460006421",
+    "barcode": "32101081340380",
+    "creation_date": "2020-12-03Z",
+    "modification_date": "2021-02-17Z",
+    "base_status": {
+      "value": "1",
+      "desc": "Item in place"
+    },
+    "awaiting_reshelving": false,
+    "physical_material_type": {
+      "value": "BOOK",
+      "desc": "Book"
+    },
+    "policy": {
+      "value": "Gen",
+      "desc": "Gen"
+    },
+    "provenance": {
+      "value": "",
+      "desc": null
+    },
+    "po_line": "",
+    "is_magnetic": false,
+    "arrival_date": "2011-12-01Z",
+    "year_of_issue": "",
+    "enumeration_a": "",
+    "enumeration_b": "",
+    "enumeration_c": "",
+    "enumeration_d": "",
+    "enumeration_e": "",
+    "enumeration_f": "",
+    "enumeration_g": "",
+    "enumeration_h": "",
+    "chronology_i": "",
+    "chronology_j": "",
+    "chronology_k": "",
+    "chronology_l": "",
+    "chronology_m": "",
+    "description": "",
+    "receiving_operator": "import",
+    "process_type": {
+      "value": "",
+      "desc": null
+    },
+    "inventory_number": "",
+    "inventory_price": "",
+    "library": {
+      "value": "recap",
+      "desc": "ReCAP"
+    },
+    "location": {
+      "value": "pa",
+      "desc": "rcppa RECAP"
+    },
+    "alternative_call_number": "",
+    "alternative_call_number_type": {
+      "value": "",
+      "desc": null
+    },
+    "storage_location_id": "",
+    "pages": "",
+    "pieces": "1",
+    "public_note": "",
+    "fulfillment_note": "",
+    "internal_note_1": "",
+    "internal_note_2": "",
+    "internal_note_3": "ON_RESERVE: N | RESERVE_CHARGES: 0 | RECALLS_PLACED: 0 | HOLDS_PLACED: 0 | HISTORICAL_BOOKINGS: 0 | SHORT_LOAN_CHARGES: 0 | ",
+    "statistics_note_1": "",
+    "statistics_note_2": "",
+    "statistics_note_3": "",
+    "requested": null,
+    "edition": null,
+    "imprint": null,
+    "language": null,
+    "physical_condition": {
+      "value": null,
+      "desc": null
+    }
+  },
+  "additional_info": "Item's destination is: Reshelve to rcppa RECAP. Request/Process Type: . Requester: . Requester ID: . Place in Queue: 0",
+  "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/9968643943506421/holdings/22258767470006421/items/23258767460006421"
+}

--- a/spec/fixtures/scan_missing_params.json
+++ b/spec/fixtures/scan_missing_params.json
@@ -1,0 +1,13 @@
+{
+  "errorsExist": true,
+  "errorList": {
+    "error": [
+      {
+        "errorCode": "40166415",
+        "errorMessage": "Must send at least one of the following parameters: [circ_desk,department]",
+        "trackingId": "E01-1702184810-FVCA7-AWAE980040178"
+      }
+    ]
+  },
+  "result": null
+}

--- a/spec/lib/bib_item_spec.rb
+++ b/spec/lib/bib_item_spec.rb
@@ -50,6 +50,31 @@ describe Alma::BibItem do
     end
   end
 
+  describe ".scan" do
+    it "hits the endpoint and returns the item" do
+      options = { op: "scan", library: "recap", circ_desk: "DEFAULT_CIRC_DESK", done: "true" }
+      item = described_class.scan(mms_id: 9968643943506421, holding_id: 22258767470006421, item_pid: 23258767460006421, options: options)
+
+      expect(a_request(:post, /.*bibs\/9968643943506421\/holdings\/22258767470006421\/items\/23258767460006421/)).to have_been_made
+      expect(item.library_name).to eq "ReCAP"
+    end
+
+    context "when required parameters are missing" do
+      it "returns an error" do
+        stub_request(:post, /.*\.exlibrisgroup\.com\/almaws\/v1\/bibs\/.*\/holdings\/.*\/items\/.*/).
+          to_return(:status => 400,
+                    :headers => { "Content-Type" => "application/json" },
+                    :body => File.open(SPEC_ROOT + '/fixtures/scan_missing_params.json'))
+
+        options = { op: "scan" }
+        item = described_class.scan(mms_id: 9968643943506421, holding_id: 22258767470006421, item_pid: 23258767460006421, options: options)
+
+        expect(a_request(:post, /.*bibs\/9968643943506421\/holdings\/22258767470006421\/items\/23258767460006421/)).to have_been_made
+        expect(item["errorsExist"]).to be true
+      end
+    end
+  end
+
   describe "instance methods" do
     let (:normal_location) {
       {

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -158,6 +158,13 @@ RSpec.configure do |config|
                  :headers => { "Content-Type" => "application/json" },
                  :body => File.open(SPEC_ROOT + '/fixtures/item_from_barcode.json'))
 
+    # Item scan
+    stub_request(:post, /.*\.exlibrisgroup\.com\/almaws\/v1\/bibs\/.*\/holdings\/.*\/items\/.*/).
+        to_return(:status => 200,
+                  :headers => { "Content-Type" => "application/json" },
+                  :body => File.open(SPEC_ROOT + '/fixtures/scan.json'))
+
+
     # Holding
     stub_request(:get, /.*\.exlibrisgroup\.com\/almaws\/v1\/bibs\/991227850000541\/holdings\/2282456310006421.*/).
       to_return(:status => 200,


### PR DESCRIPTION
The POST endpoint used here is described in alma's API documentation as "Scan-in operation on item"

At Princeton this endpoint is used to allow an external shared-storage inventory system to pass-through a discharge / scan-in in order to mark the item present at its location after transit.