### PR TITLE
Make sure fee is always the same type.

### DIFF
--- a/lib/alma/user.rb
+++ b/lib/alma/user.rb
@@ -57,7 +57,7 @@ module Alma
     end
 
     def total_fines
-      response.dig("fees", "value") || "0"
+      response.dig("fees", "value") || 0.0
     end
 
     def total_requests

--- a/spec/lib/user_spec.rb
+++ b/spec/lib/user_spec.rb
@@ -51,8 +51,12 @@ describe Alma::User do
         expect(user.total_loans).to eql "14"
       end
 
-      it "returns 0 if the element is missing" do
-        expect(user.total_fines).to eql "0"
+      it "returns 0.0 if the element is missing" do
+        expect(user.total_fines).to eql 0.0
+      end
+
+      it "returns something that can be measured" do
+        expect(user.total_fines).to be >= 0
       end
     end
 


### PR DESCRIPTION
Usually if the user has no fees/fines it is returned as 0.0, but in case of
nil we have been setting it to a string ('0').

By defaulting to the 0.0 value  instead of a '0' string we can reliably
count on using `user.total_fines > 0`  or `user.total_fines > 0.0` which
would fail if `user.total_fines == '0'`.