### PR TITLE
Fix 'method parameter is not valid' error.

### DIFF
--- a/lib/alma/user.rb
+++ b/lib/alma/user.rb
@@ -174,7 +174,7 @@ module Alma
       # @option args [String] :user_id The unique id of the user
       def self.send_payment(args)
         user_id = args.delete(:user_id) { raise ArgumentError }
-        params = { op: "pay", amount: "ALL" }
+        params = { op: "pay", amount: "ALL", method: "ONLINE" }
         response = HTTParty.post("#{users_base_path}/#{user_id}/fees/all", query: params, headers: headers)
         PaymentResponse.new(response)
       end


### PR DESCRIPTION
According to the Alma API:

```
method
string
(query)
The Payment method. Relevant and mandatory if op=pay. Options are CREDIT_CARD, ONLINE, or CASH
```

Thus without setting `method` param we generate an error and the user's fees do not get wiped.

This commit adds a value of `method=OLINE` in order to fix this error.