### PR TITLE
BL-1717 Fix alma_rb fetch bug for new API.

### DIFF
--- a/lib/alma/fine_set.rb
+++ b/lib/alma/fine_set.rb
@@ -12,8 +12,8 @@ module Alma
       @raw_response = raw_response
       @response = raw_response.parsed_response
       validate(raw_response)
-      @results = @response.fetch(key, [])
-        .map { |item| single_record_class.new(item) }
+      @results = @response.fetch(key, []) || []
+      @results.map! { |item| single_record_class.new(item) }
     end
 
     def loggable

--- a/lib/alma/loan_set.rb
+++ b/lib/alma/loan_set.rb
@@ -16,8 +16,8 @@ module Alma
       @response = raw_response.parsed_response
       @search_args = search_args
       validate(raw_response)
-      @results = @response.fetch(key, [])
-        .map { |item| single_record_class.new(item) }
+      @results = @response.fetch(key, []) || []
+      @results.map! { |item| single_record_class.new(item) }
       # args passed to the search that returned this set
       # such as limit, expand, order_by, etc
     end

--- a/lib/alma/request_set.rb
+++ b/lib/alma/request_set.rb
@@ -14,8 +14,8 @@ module Alma
       @raw_response = raw_response
       @response = raw_response.parsed_response
       validate(raw_response)
-      @results = @response.fetch(key, [])
-                   .map { |item| single_record_class.new(item) }
+      @results = @response.fetch(key, []) || []
+      @results.map! { |item| single_record_class.new(item) }
     end
 
     def loggable


### PR DESCRIPTION
Requests to the old API would return objects like

```
{"item_loan"=>[] "total_record_count"=>0}
```

But now it's returning the comparable object
```
{"item_loan"=>nil, "total_record_count"=>0}
```

This change updates the library so that it properly handles request
resources that are set to nil by the response object.