### PR TITLE
Remove ezwadl dependancy.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,5 +5,4 @@ source "https://rubygems.org"
 # Specify your gem's dependencies in alma.gemspec
 gemspec
 
-gem "ezwadl", git: "https://github.com/tulibraries/ezwadl.git", branch: "master"
 gem "simplecov", require: false, group: :test

--- a/alma.gemspec
+++ b/alma.gemspec
@@ -23,7 +23,6 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "ezwadl"
   spec.add_dependency "httparty"
   spec.add_dependency "xml-simple"
   spec.add_dependency "activesupport"


### PR DESCRIPTION
We can remove the ezwadl depency now that we no longer use blacklight_alma.