### PR TITLE
ItemRequest addition validation fix

### DIFF
--- a/lib/alma/request.rb
+++ b/lib/alma/request.rb
@@ -157,6 +157,8 @@ module Alma
     end
 
     def additional_validation!(args)
+      return unless args.fetch(:request_type) == "DIGITIZATION"
+
       args.fetch(:description) do
         raise ArgumentError.new(
           ":description option must be specified when request_type is DIGITIZATION"

--- a/spec/lib/request_spec.rb
+++ b/spec/lib/request_spec.rb
@@ -179,9 +179,19 @@ describe Alma::ItemRequest do
         expect { described_class.submit({ mms_id: "foo" }) }.to raise_error(ArgumentError, /:user_id option/)
       end
 
-      it "raises an Error when description is not an included option" do
+      it "raises an Error when holding_type is DIGITIZATION and description is not an included option" do
         options = { mms_id: "foo", holding_id: "hold", item_pid: "pid", user_id: "user", request_type: "DIGITIZATION", target_destination: "DIGI_DEPT_INST", partial_digitization: false }
         expect { described_class.submit(options) }.to raise_error(ArgumentError, /:description option/)
+      end
+
+      it "raises an Error when holding_type is HOLD and pickup_location_type is not an included option" do
+        options = { mms_id: "foo", holding_id: "hold", item_pid: "pid", user_id: "user", request_type: "HOLD" }
+        expect { described_class.submit(options) }.to raise_error(ArgumentError, /:pickup_location_type option/)
+      end
+
+      it "raises an Error when holding_type is HOLD and pickup_location_type is not an included option" do
+        options = { mms_id: "foo", holding_id: "hold", item_pid: "pid", user_id: "user", request_type: "HOLD", pickup_location_type: "LIBRARY" }
+        expect { described_class.submit(options) }.to raise_error(ArgumentError, /:pickup_location_library option/)
       end
 
       it "raises an Error when request_type is not an included option" do


### PR DESCRIPTION
This MR addresses a bug described in #96. This could very well not be the best solution, but I figured I could start the conversation here. I'm not quite sure why this additional validation is run only for Item level requests and not run for digitization requests on the BibRequest class. [Alma API docs](https://developers.exlibrisgroup.com/alma/apis/docs/xsd/rest_user_request.xsd/?tags=POST) imply that a HOLD request is allowed for item level requests, so I guess that's a start.